### PR TITLE
Always retry alternatives.install states

### DIFF
--- a/clion/linuxenv.sls
+++ b/clion/linuxenv.sls
@@ -31,6 +31,9 @@ clion-home-alt-install:
     - link: '{{ clion.jetbrains.home }}/clion'
     - path: '{{ clion.jetbrains.realhome }}'
     - priority: {{ clion.linux.altpriority }}
+    - retry:
+        attempts: 2
+        until: True
 
 clion-home-alt-set:
   alternatives.set:
@@ -38,6 +41,9 @@ clion-home-alt-set:
     - path: {{ clion.jetbrains.realhome }}
     - onchanges:
       - alternatives: clion-home-alt-install
+    - retry:
+        attempts: 2
+        until: True
 
 # Add to alternatives system
 clion-alt-install:
@@ -49,6 +55,9 @@ clion-alt-install:
     - require:
       - alternatives: clion-home-alt-install
       - alternatives: clion-home-alt-set
+    - retry:
+        attempts: 2
+        until: True
 
 clion-alt-set:
   alternatives.set:
@@ -56,6 +65,9 @@ clion-alt-set:
     - path: {{ clion.jetbrains.realcmd }}
     - onchanges:
       - alternatives: clion-alt-install
+    - retry:
+        attempts: 2
+        until: True
 
   {% endif %}
 

--- a/clion/map.jinja
+++ b/clion/map.jinja
@@ -22,10 +22,10 @@
 {% endif %}
 
 # Get dynamic release metadata
-{%- set pcode = pcode ~ ide.jetbrains.edition %}
-{% if grains.os == 'MacOS' or ide.jetbrains.edition in ('None',) %}
-   {%- set pcode = ide.jetbrains.product %}
-{% endif %}
+{%- set pcode = ide.jetbrains.product %}
+{%- if grains.os != 'MacOS' %}
+    {%- set pcode = pcode ~ ide.jetbrains.edition if ide.jetbrains.edition else pcode %}
+{%- endif %}
 {%- set jdata = salt['cmd.run']('curl {0} {1}{2}'.format(ide.dl.opts, ide.jetbrains.uri, pcode))|load_yaml %}
 
 # Extract download details


### PR DESCRIPTION
This PR introduces retries because salt `alternatives.install` always fails on 1st run.

Verified on SuSE


```
        ID: clion-home-alt-install
    Function: alternatives.install
        Name: clion-home
      Result: True
     Comment: Attempt 1: Returned a result of "False", with the following comment: "Alternative for clion-home not installed: update-alternatives: using /usr/local/jetbrains/clion-2019.1 to provide /opt/jetbrains/clion (clion-home) in auto mode"
              Alternatives for clion-home is already set to /usr/local/jetbrains/clion-2019.1
     Started: 23:46:21.932125
    Duration: 30072.753 ms
     Changes:   
----------
          ID: clion-home-alt-set
    Function: alternatives.set
        Name: clion-home
      Result: True
     Comment: State was not run because none of the onchanges reqs changed
     Changes:   
----------
          ID: clion-alt-install
    Function: alternatives.install
        Name: clion
      Result: True
     Comment: Attempt 1: Returned a result of "False", with the following comment: "Alternative for clion not installed: update-alternatives: using /usr/local/jetbrains/clion-2019.1/bin/clion.sh to provide /usr/bin/clion (clion) in auto mode"
              Alternatives for clion is already set to /usr/local/jetbrains/clion-2019.1/bin/clion.sh
     Started: 23:46:52.035221
    Duration: 30053.326 ms
     Changes:   
----------
          ID: clion-alt-set
    Function: alternatives.set
        Name: clion
      Result: True
     Comment: State was not run because none of the onchanges reqs changed
     Changes:   
```